### PR TITLE
Improved compatibility with HS2_StudioWindowResize

### DIFF
--- a/Studio_AnimationSearch/Studio_AnimationSearch.cs
+++ b/Studio_AnimationSearch/Studio_AnimationSearch.cs
@@ -61,18 +61,17 @@
 
             animeListsBase = Singleton<Info>.Instance.dicAnimeLoadInfo;
             groupListPanel = this.transform.Find("Group Panel").gameObject;
+            Transform parentSearchbar = groupListPanel.transform; 
 #if AI
             GameObject workspaceSearchbar = this.transform.parent.parent.parent.Find("Canvas Object List").Find("Image Bar").Find("Scroll View").Find("Search").gameObject;
-            searchBar = GameObject.Instantiate(workspaceSearchbar, this.transform);
+            searchBar = GameObject.Instantiate(workspaceSearchbar, parentSearchbar);
 #else
             GameObject workspaceSearchbar = this.transform.parent.parent.parent.Find("Canvas Object List").Find("Image Bar").Find("Scroll View").Find("Search").gameObject;
-            searchBar = GameObject.Instantiate(workspaceSearchbar, this.transform);
+            searchBar = GameObject.Instantiate(workspaceSearchbar, parentSearchbar);
 #endif
             RectTransform rect = searchBar.GetComponent<RectTransform>();
-            rect.anchorMin = new Vector2(0, 1);
-            rect.anchorMax = new Vector2(0, 1);
-            rect.offsetMin = new Vector2(0, -320f);
-            rect.offsetMax = new Vector2(250, -290f);
+            rect.offsetMin = new Vector2(0, -30f);
+            rect.offsetMax = new Vector2(130, 0f);
 
             InputField input = searchBar.GetComponent<InputField>();
             input.onEndEdit.RemoveAllListeners();


### PR DESCRIPTION
Hello
An overlapping issue occurred because Studio_AnimationSearch could not adapt to the vertically increased length by HS2_StudioWindowResize

I tried to port this to KK, but the translate stuff in this code didn't work well in KK and it felt very heavy. Maybe it needs caching stuff  Also, the nodes of AnimeGroupList and AnimeCategoryList were not filtered. I assume it was because the InitList was different from the ones in HS2/AI

Anyway, I made a PR for something I can improve right now